### PR TITLE
Use a more meaningful URL than 'localhost' and use it for StartupWMClass

### DIFF
--- a/data/org.learningequality.KALite.desktop.in
+++ b/data/org.learningequality.KALite.desktop.in
@@ -8,3 +8,4 @@ Exec=kalite-app
 Categories=Education;
 Terminal=false
 Icon=org.learningequality.KALite
+StartupWMClass=org.learningequality.KALite.localhost

--- a/src/kalite-app.py
+++ b/src/kalite-app.py
@@ -27,7 +27,7 @@ from gi.repository import Gio
 from gi.repository import GLib
 
 # Where the KA Lite server will be listening.
-KALITE_SERVER_URI='http://localhost:8008'
+KALITE_SERVER_URI='http://org.learningequality.KALite.localhost:8008'
 
 # We use a custom URI that will be handled by chromium-browser-appmode
 # so that chromium-browser gets launched with --class and -app set.


### PR DESCRIPTION
This will allow running KA Lite with the right icon and being properly
managed by the Window Manager even when running through a shared
browsing session (i.e. not using an app-specific data directory).

https://phabricator.endlessm.com/T12907
